### PR TITLE
Register spot nodes with different role

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ $(BINARY_NAME): generate
 compress: $(BINARY_NAME)
 	strip -x $(BINARY_NAME)
 	$(UPX) $(BINARY_NAME)
-test:
+test: generate
 	$(GOTEST) -coverprofile=coverage.txt -covermode=count ./...
 install-linter:
 	$(GOCMD) get -u github.com/alecthomas/gometalinter

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -36,6 +36,7 @@ type Node struct {
 	ReservedMemory string
 	ClusterDNS     string
 	Region         string
+	Spot           bool
 }
 
 type metadataClient interface {
@@ -60,7 +61,7 @@ func New(e ec2iface.EC2API, m metadataClient, region *string) (*Node, error) {
 			return nil, err
 		}
 		instance := output.Reservations[0].Instances[0]
-		node := Node{Instance: instance, MaxPods: maxPods(instance.InstanceType), ReservedCPU: reservedCPU(instance.InstanceType), ReservedMemory: reservedMemory(instance.InstanceType), ClusterDNS: clusterDNS(instance.PrivateIpAddress), Region: *region}
+		node := Node{Instance: instance, MaxPods: maxPods(instance.InstanceType), ReservedCPU: reservedCPU(instance.InstanceType), ReservedMemory: reservedMemory(instance.InstanceType), ClusterDNS: clusterDNS(instance.PrivateIpAddress), Region: *region, Spot: spot(instance.InstanceLifecycle)}
 		if node.ClusterName() == "" {
 			sleepFor := b.Duration(tries)
 			log.Printf("The kubernetes.io/cluster/<name> tag is not yet set, will try again in %s", sleepFor)
@@ -83,6 +84,13 @@ func (n *Node) ClusterName() string {
 		}
 	}
 	return ""
+}
+
+func spot(lifecycleType *string) bool {
+	if lifecycleType != nil && *lifecycleType == ec2.InstanceLifecycleTypeSpot {
+		return true
+	}
+	return false
 }
 
 func instanceID(m metadataClient) (*string, error) {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -360,6 +360,57 @@ func TestMemory(t *testing.T) {
 	}
 }
 
+func TestSpot(t *testing.T) {
+	tests := []struct {
+		lifecycleType string
+		expected      bool
+	}{
+		{
+
+			lifecycleType: ec2.InstanceLifecycleTypeSpot,
+			expected:      true,
+		},
+		{
+
+			lifecycleType: ec2.InstanceLifecycleTypeScheduled,
+			expected:      false,
+		},
+		{
+			// OnDemand instances do not return this field
+			lifecycleType: "",
+			expected:      false,
+		},
+		{
+
+			lifecycleType: "something-unexpected",
+			expected:      false,
+		},
+	}
+
+	for _, test := range tests {
+		e := &mockEC2{
+			tags: [][]*ec2.Tag{
+				{tag("kubernetes.io/cluster/cluster-name", "owned")},
+			},
+			lifecycleType: test.lifecycleType,
+		}
+		metadata := mockMetadata{
+			data: map[string]string{
+				"instance-id": "1234",
+			},
+		}
+		region := "us-west-2"
+		node, err := New(e, metadata, &region)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		}
+
+		if node.Spot != test.expected {
+			t.Errorf("expected Spot for %v to be: %v, but it was %v", test.lifecycleType, test.expected, node.Spot)
+		}
+	}
+}
+
 func tag(key, value string) *ec2.Tag {
 	return &ec2.Tag{
 		Key:   &key,
@@ -370,9 +421,10 @@ func tag(key, value string) *ec2.Tag {
 type mockEC2 struct {
 	PrivateIPAddress string
 	ec2iface.EC2API
-	tags         [][]*ec2.Tag
-	instanceType string
-	err          error
+	tags          [][]*ec2.Tag
+	instanceType  string
+	err           error
+	lifecycleType string
 }
 
 func (m *mockEC2) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
@@ -382,15 +434,20 @@ func (m *mockEC2) DescribeInstances(input *ec2.DescribeInstancesInput) (*ec2.Des
 	var tags []*ec2.Tag
 	//Pop the first set of tags
 	tags, m.tags = m.tags[0], m.tags[1:]
+	var lifecycleType *string
+	if m.lifecycleType != "" {
+		lifecycleType = &m.lifecycleType
+	}
 	if len(input.InstanceIds) > 0 {
 		return &ec2.DescribeInstancesOutput{
 			Reservations: []*ec2.Reservation{{
 				Instances: []*ec2.Instance{
 					{
-						InstanceId:       input.InstanceIds[0],
-						Tags:             tags,
-						InstanceType:     &m.instanceType,
-						PrivateIpAddress: &m.PrivateIPAddress,
+						InstanceId:        input.InstanceIds[0],
+						Tags:              tags,
+						InstanceType:      &m.instanceType,
+						PrivateIpAddress:  &m.PrivateIPAddress,
+						InstanceLifecycle: lifecycleType,
 					},
 				},
 			},

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -69,7 +69,9 @@ func (s System) Configure(n *node.Node, cluster *eks.Cluster) error {
 	}
 
 	for _, config := range configs {
-		config.write(info)
+		if config.write(info) != nil {
+			return err
+		}
 	}
 
 	return s.Init.EnsureRunning("kubelet.service")

--- a/pkg/system/templates/etc/systemd/system/kubelet.service
+++ b/pkg/system/templates/etc/systemd/system/kubelet.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/kubelet \
   --kubeconfig=/var/lib/kubelet/kubeconfig \
   --feature-gates=RotateKubeletServerCertificate=true \
   --anonymous-auth=false \
-  --client-ca-file=/etc/kubernetes/pki/ca.crt $KUBELET_ARGS $KUBELET_MAX_PODS $KUBELET_KUBE_RESERVED $KUBELET_EXTRA_ARGS
+  --client-ca-file=/etc/kubernetes/pki/ca.crt $KUBELET_ARGS $KUBELET_MAX_PODS $KUBELET_KUBE_RESERVED $KUBELET_SPOT_ARGS $KUBELET_EXTRA_ARGS
 
 Restart=always
 StartLimitInterval=0

--- a/pkg/system/templates/etc/systemd/system/kubelet.service.d/40-spot-args.conf
+++ b/pkg/system/templates/etc/systemd/system/kubelet.service.d/40-spot-args.conf
@@ -1,0 +1,6 @@
+[Service]
+{{- if .Node.Spot }}
+Environment='KUBELET_SPOT_ARGS=--node-labels="node-role.kubernetes.io/spot-worker=true"'
+{{ else }}
+Environment='KUBELET_SPOT_ARGS=--node-labels="node-role.kubernetes.io/worker=true" --register-with-taints="node-role.kubernetes.io/worker=true:PreferNoSchedule"'
+{{ end -}}


### PR DESCRIPTION
* Taint on-demand instances so we prefer spot instances
unless the node selector requires it, or there are no
spot instances avalible.

* Based on this https://github.com/pusher/k8s-spot-rescheduler#requirements